### PR TITLE
Change package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Template application",
+  "name": "template-application",
   "version": "3.0.0",
   "author": "Timur Shemsedinov <timur.shemsedinov@gmail.com>",
   "description": "Metarhia application minimal template",


### PR DESCRIPTION
The package name should not contain spaces or capital letters

![image](https://github.com/metarhia/Template/assets/5096735/1c215cb2-7ef6-4c75-839a-610c5ef3939a)

It makes impossible to use `yarn` as a package manager

```bash
$ yarn
yarn install v1.22.19
error package.json: Name contains illegal characters
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```